### PR TITLE
Fix Qt enum names for PyQt6 compatibility

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -145,8 +145,8 @@ class MainViewerWindow(QMainWindow):
             pixmap = QPixmap.fromImage(qimg)
             pixmap = pixmap.scaled(
                 self.ui.videoLabel.size(),
-                Qt.KeepAspectRatio,
-                Qt.SmoothTransformation,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
             )
             self.ui.videoLabel.setPixmap(pixmap)
         self.ax.clear()
@@ -188,8 +188,8 @@ class MainViewerWindow(QMainWindow):
         pixmap = QPixmap.fromImage(qimg)
         pixmap = pixmap.scaled(
             self.ui.videoLabel.size(),
-            Qt.KeepAspectRatio,
-            Qt.SmoothTransformation,
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
         )
         self.ui.videoLabel.setPixmap(pixmap)
         self.update_spectrum(index)


### PR DESCRIPTION
## Summary
- use PyQt6 enum paths for aspect ratio and transformation modes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e8b8550e4832fb9d395955540f84e