### PR TITLE
Add integration time to plot titles

### DIFF
--- a/tests/test_video_spectra_viewer_methods.py
+++ b/tests/test_video_spectra_viewer_methods.py
@@ -64,3 +64,26 @@ def test_show_next_frame_calls_update(monkeypatch):
 
     assert viewer.current_frame_index == 1
     assert called.get("update")
+
+
+def test_plot_title_includes_integration_time(monkeypatch):
+    VideoSpectraViewer, _ = load_viewer(monkeypatch)
+    viewer = VideoSpectraViewer.__new__(VideoSpectraViewer)
+
+    captured = {}
+    axis = types.SimpleNamespace(
+        plot=lambda *a, **k: None,
+        set_xlabel=lambda *a, **k: None,
+        set_ylabel=lambda *a, **k: None,
+        set_title=lambda text: captured.setdefault("title", text),
+    )
+    viewer.figure = types.SimpleNamespace(
+        clear=lambda: None,
+        add_subplot=lambda *a, **k: axis,
+    )
+    viewer.canvas = types.SimpleNamespace(draw=lambda: None)
+
+    spectra = {"timestamp": 1.0, "IntegrationTime": 50, "500": 0.1}
+    viewer._plot_spectra(spectra)
+
+    assert "Integration" in captured.get("title", "")

--- a/viewer.py
+++ b/viewer.py
@@ -213,6 +213,10 @@ class MainViewerWindow(QMainWindow):
         self.ax.clear()
         self._plot_spectra(row)
         title = f"Spectrum at {row['timestamp']}"
+        integration = row.get('IntegrationTime')
+        if integration is not None and not pd.isna(integration):
+            title += f" (Integration: {integration})"
+
         subtitle = (
             f"Spec Row {row_index + 1}/{len(self.spectral_df)} "
             f"Frame {self.current_frame + 1}/{self.total_frames}"

--- a/viewer/video_spectra_viewer.py
+++ b/viewer/video_spectra_viewer.py
@@ -144,7 +144,17 @@ class VideoSpectraViewer(QtWidgets.QMainWindow):
         ax.plot(x, y, marker="o")
         ax.set_xlabel("Wavelength")
         ax.set_ylabel("Intensity")
-        ax.set_title(f"Timestamp: {spectra['timestamp']:.2f}s")
+
+        title = f"Timestamp: {spectra['timestamp']:.2f}s"
+        for key in spectra:
+            lowered = key.lower().replace(" ", "")
+            if lowered in {"integrationtime", "integration_time"}:
+                integration = spectra.get(key)
+                if integration is not None and integration == integration:
+                    title += f" | Integration: {integration}"
+                break
+
+        ax.set_title(title)
         self.canvas.draw()
 
     # -------------------------- Metadata Handling --------------------------


### PR DESCRIPTION
## Summary
- show integration time in spectral plot titles for both viewer UIs
- test viewer helper for new integration time title logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fc6f4e858832f86bdbebbbc086f14