### PR TITLE
Dark theme for spectral graph

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -61,6 +61,8 @@ class MainViewerWindow(QMainWindow):
         self.canvas = FigureCanvas(self.figure)
         self.ax = self.figure.add_subplot(111)
 
+        self._apply_dark_theme()
+
         plot_layout = self.ui.plotWidget.layout()
         if plot_layout is None:
             plot_layout = QVBoxLayout(self.ui.plotWidget)
@@ -85,6 +87,18 @@ class MainViewerWindow(QMainWindow):
             self.ui.analyzeButton.clicked.connect(self.analyze_data)
 
         self.display_row(0)
+
+    def _apply_dark_theme(self) -> None:
+        """Configure the matplotlib plot with a dark theme."""
+        bg_color = "#2b2b2b"
+        self.figure.set_facecolor(bg_color)
+        self.ax.set_facecolor(bg_color)
+        for spine in self.ax.spines.values():
+            spine.set_color("white")
+        if hasattr(self.ax, "tick_params"):
+            self.ax.tick_params(colors="white", labelcolor="white")
+        self.ax.set_xlabel("Wavelength", color="white")
+        self.ax.set_ylabel("Intensity", color="white")
 
     # ------------------------------------------------------------------
     # Data Import Actions
@@ -211,6 +225,7 @@ class MainViewerWindow(QMainWindow):
 
     def update_spectrum_row(self, row_index: int, row: pd.Series) -> None:
         self.ax.clear()
+        self._apply_dark_theme()
         self._plot_spectra(row)
         title = f"Spectrum at {row['timestamp']}"
         integration = row.get('IntegrationTime')
@@ -221,7 +236,7 @@ class MainViewerWindow(QMainWindow):
             f"Spec Row {row_index + 1}/{len(self.spectral_df)} "
             f"Frame {self.current_frame + 1}/{self.total_frames}"
         )
-        self.ax.set_title(f"{title}\n{subtitle}")
+        self.ax.set_title(f"{title}\n{subtitle}", color="white")
         self.canvas.draw()
 
     def update_metadata_table(self, index: int) -> None:
@@ -284,7 +299,8 @@ class MainViewerWindow(QMainWindow):
             keys.append(k)
         keys = sorted(keys, key=float)
         values = [float(spectra_row[k]) for k in keys]
-        self.ax.plot([float(k) for k in keys], values)
+        line_color = "#66b3ff"
+        self.ax.plot([float(k) for k in keys], values, color=line_color)
 
     def _save_current_metadata(self) -> None:
         for col_idx, col in enumerate(self.metadata_df.columns):

--- a/viewer/video_spectra_viewer.py
+++ b/viewer/video_spectra_viewer.py
@@ -73,6 +73,11 @@ class VideoSpectraViewer(QtWidgets.QMainWindow):
         self.canvas = FigureCanvas(self.figure)
         video_plot_layout.addWidget(self.canvas)
 
+        # apply a dark theme to the plot area
+        bg_color = "#2b2b2b"
+        self.figure.set_facecolor(bg_color)
+        self.canvas.setStyleSheet(f"background-color: {bg_color};")
+
         video_plot_layout.setStretch(0, 1)
         video_plot_layout.setStretch(1, 1)
         layout.addLayout(video_plot_layout)
@@ -139,11 +144,21 @@ class VideoSpectraViewer(QtWidgets.QMainWindow):
         """Plot spectral data on matplotlib canvas."""
         self.figure.clear()
         ax = self.figure.add_subplot(111)
+        bg_color = "#2b2b2b"
+        line_color = "#66b3ff"
+
+        if hasattr(ax, "set_facecolor"):
+            ax.set_facecolor(bg_color)
+
         x = [k for k in spectra.keys() if k != "timestamp"]
         y = [spectra[k] for k in x]
-        ax.plot(x, y, marker="o")
-        ax.set_xlabel("Wavelength")
-        ax.set_ylabel("Intensity")
+        ax.plot(x, y, marker="o", color=line_color)
+        ax.set_xlabel("Wavelength", color="white")
+        ax.set_ylabel("Intensity", color="white")
+        if hasattr(ax, "tick_params"):
+            ax.tick_params(colors="white", labelcolor="white")
+        for spine in getattr(ax, "spines", {}).values():
+            spine.set_color("white")
 
         title = f"Timestamp: {spectra['timestamp']:.2f}s"
         for key in spectra:
@@ -155,6 +170,8 @@ class VideoSpectraViewer(QtWidgets.QMainWindow):
                 break
 
         ax.set_title(title)
+        if hasattr(ax, "title") and hasattr(ax.title, "set_color"):
+            ax.title.set_color("white")
         self.canvas.draw()
 
     # -------------------------- Metadata Handling --------------------------


### PR DESCRIPTION
## Summary
- apply dark theme styling to the matplotlib canvas in `VideoSpectraViewer`
- add helper for dark styling in `MainViewerWindow`
- recolor graph lines and text for visibility
- keep tests working with feature-detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fca2a269c832fb9af07d464e3d07e